### PR TITLE
fix(eslint): allow shared→shared imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,7 +54,12 @@ export default tseslint.config(
           { from: { type: 'widgets' },  allow: { to: { type: ['features', 'entities', 'shared'] } } },
           { from: { type: 'features' }, allow: { to: { type: ['entities', 'shared'] } } },
           { from: { type: 'entities' }, allow: { to: { type: ['shared'] } } },
-          { from: { type: 'shared' },   disallow: { to: { type: '*' } } },
+          // FSD allows shared→shared (cross-module utilities, locale files,
+          // shared dictionaries). The previous '*' disallow was too tight
+          // and flagged legitimate same-segment imports — e.g.
+          // `shared/i18n/index.ts` importing JSON locales from
+          // `shared/i18n/locales/`.
+          { from: { type: 'shared' },   allow: { to: { type: ['shared'] } } },
         ],
       }],
 


### PR DESCRIPTION
## Summary

CI on master has been failing since Phase 78 (2026-04-21) on
two boundary errors in \`src/shared/i18n/index.ts\`:

\`\`\`
24:22  error  Dependencies to elements of type \"shared\" are not allowed in elements of type \"shared\". Denied by rule at index 5  boundaries/dependencies
25:22  error  Dependencies to elements of type \"shared\" are not allowed in elements of type \"shared\". Denied by rule at index 5  boundaries/dependencies
\`\`\`

Lines 24-25 are legitimate JSON locale imports:

\`\`\`ts
import enCommon from './locales/en/common.json'
import ruCommon from './locales/ru/common.json'
\`\`\`

The prior \`disallow: { to: { type: '*' } }\` rule on \`shared\` was
overly strict — FSD does allow shared utilities to compose with each
other. Replaced with explicit \`allow: { to: { type: ['shared'] } }\`.

This unblocks CI for #28 (just merged) and every other PR that touches
or merges through a shared file.

## Test plan
- [x] \`pnpm lint\` exit 0 locally (7 pre-existing warnings remain;
      console.* in migrate/i18n + 1 unused eslint-disable; warnings
      don't block CI)
- [x] \`pnpm tsc --noEmit\` ✓
- [ ] CI runs green on this PR